### PR TITLE
Bugfix: implement priorities properly and add test

### DIFF
--- a/src/DI/EventDispatcherExtension.php
+++ b/src/DI/EventDispatcherExtension.php
@@ -94,20 +94,24 @@ class EventDispatcherExtension extends CompilerExtension
 			 */
 			foreach ($events as $event => $args) {
 				if (is_string($args)) {
-					$dispatcher->addSetup('addSubscriberLazy', [$event, $name]);
-				} else if (is_string($args[0])) {
-					if (!method_exists($subscriber, $args[0])) {
-						throw new ServiceCreationException(sprintf('Event listener %s does not have callable method %s', get_class($subscriber), $args[0]));
+					if (!method_exists($subscriber->getClass(), $args)) {
+						throw new ServiceCreationException(sprintf('Event listener %s does not have callable method %s', $subscriber->getClass(), $args));
 					}
 
-					$dispatcher->addSetup('addSubscriberLazy', [$event, $args[0]]);
+					$dispatcher->addSetup('addSubscriberLazy', [$event, $name]);
+				} else if (is_string($args[0])) {
+					if (!method_exists($subscriber->getClass(), $args[0])) {
+						throw new ServiceCreationException(sprintf('Event listener %s does not have callable method %s', $subscriber->getClass(), $args[0]));
+					}
+
+					$dispatcher->addSetup('addSubscriberLazy', [$event, $name]);
 				} else {
 					foreach ($args as $arg) {
-						if (!method_exists($subscriber, $arg[0])) {
-							throw new ServiceCreationException(sprintf('Event listener %s does not have callable method %s', get_class($subscriber), $arg[0]));
+						if (!method_exists($subscriber->getClass(), $arg[0])) {
+							throw new ServiceCreationException(sprintf('Event listener %s does not have callable method %s', $subscriber->getClass(), $arg[0]));
 						}
 
-						$dispatcher->addSetup('addSubscriberLazy', [$event, $arg[0]]);
+						$dispatcher->addSetup('addSubscriberLazy', [$event, $name]);
 					}
 				}
 			}

--- a/tests/fixtures/PrioritizedSubscriber.php
+++ b/tests/fixtures/PrioritizedSubscriber.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @author Jiří Pudil <me@jiripudil.cz>
+ */
+final class PrioritizedSubscriber implements EventSubscriberInterface
+{
+
+	/** @var array */
+	public $onCall = [];
+
+	/**
+	 * @return array The event names to listen to
+	 */
+	public static function getSubscribedEvents()
+	{
+		return ['prioritized' => ['onPrioritized', 1]];
+	}
+
+	/**
+	 * @param Event $event
+	 * @return void
+	 */
+	public function onPrioritized(Event $event)
+	{
+		$this->onCall[] = $event;
+	}
+
+}


### PR DESCRIPTION
I've got this error when trying to use a prioritized subscriber:

```
Event listener Nette\DI\ServiceDefinition does not have callable method onEvent
```

I dug into the code and found out that subscribers with priorities were not registered correctly with `lazy: true`. This hopefully fixes the problem.