### PR TITLE
Tracy: add option to set max depth of dumped contents

### DIFF
--- a/src/DI/EventDispatcherExtension.php
+++ b/src/DI/EventDispatcherExtension.php
@@ -32,6 +32,7 @@ class EventDispatcherExtension extends CompilerExtension
 			'lazy' => Expect::bool(true),
 			'autoload' => Expect::bool(true),
 			'debug' => Expect::bool(false),
+			'debugContentDepth' => Expect::int(2),
 			'loggers' => Expect::arrayOf(Expect::type(Statement::class)),
 		]);
 	}
@@ -92,7 +93,13 @@ class EventDispatcherExtension extends CompilerExtension
 				// @phpstan-ignore-next-line
 				$builder->formatPhp('?->addPanel(?);', [
 					$builder->getDefinitionByType(Bar::class),
-					new Statement(EventPanel::class, [$builder->getDefinition($this->prefix('dispatcher.tracy'))]),
+					new Statement(
+						EventPanel::class,
+						[
+							$builder->getDefinition($this->prefix('dispatcher.tracy')),
+							$config->debugContentDepth,
+						]
+					),
 				])
 			);
 		}

--- a/src/Tracy/EventPanel.php
+++ b/src/Tracy/EventPanel.php
@@ -9,10 +9,12 @@ class EventPanel implements IBarPanel
 {
 
 	private TracyDispatcher $dispatcher;
+	private int $debugContentDepth;
 
-	public function __construct(TracyDispatcher $dispatcher)
+	public function __construct(TracyDispatcher $dispatcher, int $debugContentDepth)
 	{
 		$this->dispatcher = $dispatcher;
+		$this->debugContentDepth = $debugContentDepth;
 	}
 
 	/**
@@ -40,6 +42,7 @@ class EventPanel implements IBarPanel
 		$totalTime = $this->countTotalTime(); // @phpcs:ignore
 		$events = $this->dispatcher->getEvents(); // @phpcs:ignore
 		$listeners = $this->dispatcher->getListeners();
+		$debugContentDepth = $this->debugContentDepth;
 		ksort($listeners);
 		ob_start();
 		require __DIR__ . '/templates/panel.phtml';

--- a/src/Tracy/templates/panel.phtml
+++ b/src/Tracy/templates/panel.phtml
@@ -1,11 +1,12 @@
 <?php
-/** @var EventInfo[] $events */
+/** @var int $debugContentDepth */
+/** @var EventTrace[] $events */
 /** @var array<string,callable> $listeners */
 /** @var int $handledCount */
 
 /** @var float $totalTime */
 
-use Contributte\EventDispatcher\Diagnostics\EventInfo;
+use Contributte\EventDispatcher\Diagnostics\EventTrace;
 use Tracy\Dumper;
 ?>
 <style>
@@ -44,7 +45,7 @@ use Tracy\Dumper;
 						</td>
 						<td><?= $e->handled ? 'yes' : 'no' ?></td>
 						<td>
-							<?= Dumper::toHtml($e->event, [Dumper::COLLAPSE => true]); ?>
+							<?= Dumper::toHtml($e->event, [Dumper::COLLAPSE => true, Dumper::DEPTH => $debugContentDepth]); ?>
 						</td>
 					</tr>
 				<?php endforeach; ?>
@@ -74,7 +75,7 @@ use Tracy\Dumper;
 								} else if ($handler instanceof \Contributte\EventDispatcher\LazyListener) {
 									echo $handler->toString();
 								} else {
-									echo Dumper::toHtml($handler);
+									echo Dumper::toHtml($handler, [Dumper::DEPTH => $debugContentDepth]);
 								}
 								?>
 							</td>
@@ -84,7 +85,7 @@ use Tracy\Dumper;
 			</table>
 
 			<div style="margin-top: var(--tracy-space);">
-				<?= Dumper::toHtml($listeners, [Dumper::COLLAPSE => true]); ?>
+				<?= Dumper::toHtml($listeners, [Dumper::COLLAPSE => true, Dumper::DEPTH => $debugContentDepth + 2]); ?>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Events (especially those from your extra package) contain core application classes,  and it's easy to cause memory overflow with a couple of events by trying to dump them, since the default depth is 7.