### PR TITLE
Config: replace debug bool with debug structure (panel, deep)

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -41,10 +41,12 @@ And automatically adds them to the event dispatcher. That's all. You don't have 
 
 ```neon
 events:
-		lazy: true
-		autoload: true
-		debug: false
-		loggers: []
+	lazy: true
+	autoload: true
+	debug:
+		panel: false
+		deep: null
+	loggers: []
 ```
 
 ### Autoload
@@ -67,12 +69,17 @@ events:
 
 ### Debug
 
-Debug option is disabled (`false`) as default. If you want to show Tracy panel, you have to enable it.
+Debug option allows you to enable Tracy panel and configure its behavior.
 
 ```neon
 events:
-	debug: %debugMode%
+	debug:
+		panel: %debugMode%
+		deep: 4
 ```
+
+- `panel` - Enable/disable Tracy debug panel (default: `false`)
+- `deep` - Maximum depth of dumped event contents in Tracy panel (default: `null` = Tracy default)
 
 ### Logging
 

--- a/src/Tracy/EventPanel.php
+++ b/src/Tracy/EventPanel.php
@@ -10,9 +10,12 @@ class EventPanel implements IBarPanel
 
 	private TracyDispatcher $dispatcher;
 
-	public function __construct(TracyDispatcher $dispatcher)
+	private ?int $deep;
+
+	public function __construct(TracyDispatcher $dispatcher, ?int $deep = null)
 	{
 		$this->dispatcher = $dispatcher;
+		$this->deep = $deep;
 	}
 
 	/**
@@ -40,6 +43,7 @@ class EventPanel implements IBarPanel
 		$totalTime = $this->countTotalTime(); // @phpcs:ignore
 		$events = $this->dispatcher->getEvents(); // @phpcs:ignore
 		$listeners = $this->dispatcher->getListeners();
+		$deep = $this->deep; // @phpcs:ignore
 		ksort($listeners);
 		ob_start();
 		require __DIR__ . '/templates/panel.phtml';

--- a/src/Tracy/templates/panel.phtml
+++ b/src/Tracy/templates/panel.phtml
@@ -2,11 +2,16 @@
 /** @var EventInfo[] $events */
 /** @var array<string,callable> $listeners */
 /** @var int $handledCount */
-
 /** @var float $totalTime */
+/** @var int|null $deep */
 
 use Contributte\EventDispatcher\Diagnostics\EventInfo;
 use Tracy\Dumper;
+
+$dumperOptions = [Dumper::COLLAPSE => true];
+if ($deep !== null) {
+	$dumperOptions[Dumper::DEPTH] = $deep;
+}
 ?>
 <style>
 	#tracy-debug .event-name, #tracy-debug .listener-name {
@@ -44,7 +49,7 @@ use Tracy\Dumper;
 						</td>
 						<td><?= $e->handled ? 'yes' : 'no' ?></td>
 						<td>
-							<?= Dumper::toHtml($e->event, [Dumper::COLLAPSE => true]); ?>
+							<?= Dumper::toHtml($e->event, $dumperOptions); ?>
 						</td>
 					</tr>
 				<?php endforeach; ?>
@@ -71,10 +76,10 @@ use Tracy\Dumper;
 								<?php
 								if (\is_array($handler) && \is_object($handler[0]) && \is_string($handler[1])) {
 									echo \get_class($handler[0]) . '::' . $handler[1];
-								} else if ($handler instanceof \Contributte\EventDispatcher\LazyListener) {
+								} elseif ($handler instanceof \Contributte\EventDispatcher\LazyListener) {
 									echo $handler->toString();
 								} else {
-									echo Dumper::toHtml($handler);
+									echo Dumper::toHtml($handler, $dumperOptions);
 								}
 								?>
 							</td>
@@ -84,7 +89,7 @@ use Tracy\Dumper;
 			</table>
 
 			<div style="margin-top: var(--tracy-space);">
-				<?= Dumper::toHtml($listeners, [Dumper::COLLAPSE => true]); ?>
+				<?= Dumper::toHtml($listeners, $dumperOptions); ?>
 			</div>
 		</div>
 	</div>

--- a/tests/Cases/DI/EventExtension.debug.phpt
+++ b/tests/Cases/DI/EventExtension.debug.phpt
@@ -20,7 +20,31 @@ Toolkit::test(function (): void {
 			$compiler->addExtension('events', new EventDispatcherExtension());
 			$compiler->addConfig(Neonkit::load(<<<'NEON'
 				events:
-					debug: true
+					debug:
+						panel: true
+			NEON
+			));
+		})->build();
+
+	$container->initialize();
+
+	/** @var Bar $bar */
+	$bar = $container->getByType(Bar::class);
+
+	Assert::notNull($bar->getPanel(EventPanel::class));
+});
+
+// Add Tracy panel with depth limit
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('tracy', new TracyExtension());
+			$compiler->addExtension('events', new EventDispatcherExtension());
+			$compiler->addConfig(Neonkit::load(<<<'NEON'
+				events:
+					debug:
+						panel: true
+						deep: 3
 			NEON
 			));
 		})->build();


### PR DESCRIPTION
BC BREAK: Change debug configuration from boolean to structure with:
- panel: bool - enable/disable Tracy debug panel
- deep: int|null - control Tracy Dumper depth to prevent memory overflow

Resolves contributte/event-dispatcher#40