### PR TITLE
Add #[AsEventListener] support

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -42,7 +42,6 @@ and all services using Symfony's `#[AsEventListener]` attribute. Matching servic
 
 ```neon
 events:
-	lazy: true
 	autoload: true
 	debug:
 		panel: false
@@ -57,15 +56,6 @@ Autoload option is enabled (`true`) as default. If you would like to register su
 ```neon
 events:
 	autoload: true/false
-```
-
-### Lazy-loading
-
-Lazy option is enabled (`true`) as default. But you can override it for both subscribers and attribute listeners.
-
-```neon
-events:
-	lazy: true/false
 ```
 
 ### Debug

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -4,6 +4,7 @@
 
 - [Setup](#setup)
 - [Configuration](#configuration)
+- [Listener - example listener](#listener)
 - [Subscriber - example subscriber](#subscriber)
 - [Dispatcher - dispatching events](#dispatcher)
 - [Extra - extra Nette bridge](#extra)
@@ -32,8 +33,8 @@ extensions:
 	events: Contributte\EventDispatcher\DI\EventDispatcherExtension
 ```
 
-The extension looks for all services implementing `Symfony\Component\EventDispatcher\EventSubscriberInterface`.
-And automatically adds them to the event dispatcher. That's all. You don't have to be worried.
+The extension looks for all services implementing `Symfony\Component\EventDispatcher\EventSubscriberInterface`
+and all services using Symfony's `#[AsEventListener]` attribute. Matching services are added to the event dispatcher automatically.
 
 ## Configuration
 
@@ -51,7 +52,7 @@ events:
 
 ### Autoload
 
-Autoload option is enabled (`true`) as default. If you would like to add all subscribers by yourself, you have to disable `autoload`.
+Autoload option is enabled (`true`) as default. If you would like to register subscribers and attribute listeners by yourself, you have to disable `autoload`.
 
 ```neon
 events:
@@ -60,7 +61,7 @@ events:
 
 ### Lazy-loading
 
-Lazy option is enabled (`true`) as default. But you can override it.
+Lazy option is enabled (`true`) as default. But you can override it for both subscribers and attribute listeners.
 
 ```neon
 events:
@@ -90,6 +91,40 @@ events:
 	loggers:
 		- App\Logger\FileLogger(%tempDir%/events.log)
 ```
+
+## Listener
+
+You can register listeners with Symfony's native `#[AsEventListener]` attribute.
+
+```php
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+final class OrderListener
+{
+
+	#[AsEventListener(event: OrderCreatedEvent::class, priority: 10)]
+	public function onOrderCreated(OrderCreatedEvent $event): void
+	{
+		// Do some magic here...
+	}
+
+	#[AsEventListener]
+	public function onOrderPaid(OrderPaidEvent $event): void
+	{
+		// The event name is inferred from the first typed argument.
+	}
+
+}
+```
+
+```neon
+services:
+	- OrderListener
+```
+
+Class-level attributes are supported too. If `method` is omitted, the extension tries `on<EventName>()` first and then `__invoke()`.
+If `event` is omitted, the first argument of the selected method must be typed with a concrete event class.
+String event names cannot be inferred, so they still need `event:`.
 
 ## Subscriber
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,14 @@ composer require contributte/event-dispatcher
 
 For details on how to use this package, check out our [documentation](.docs).
 
+Autoloaded services can be registered either as Symfony event subscribers or with Symfony's native `#[AsEventListener]` attribute.
+
 ## Versions
 
 | State       | Version | Branch   | Nette | PHP     |
 |-------------|---------|----------|-------|---------|
-| dev         | `^0.10` | `master` | 3.1+  | `>=8.1` |
-| stable      | `^0.9`  | `master` | 3.1+  | `>=8.1` |
+| dev         | `^0.10` | `master` | 3.1+  | `>=8.2` |
+| stable      | `^0.9`  | `master` | 3.1+  | `>=8.2` |
 
 ## Development
 

--- a/src/DI/EventDispatcherExtension.php
+++ b/src/DI/EventDispatcherExtension.php
@@ -14,10 +14,15 @@ use Nette\DI\ServiceCreationException;
 use Nette\PhpGenerator\ClassType;
 use Nette\Schema\Expect;
 use Nette\Schema\Schema;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
 use stdClass;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\Event;
 use Tracy\Bar;
 
 /**
@@ -117,6 +122,8 @@ class EventDispatcherExtension extends CompilerExtension
 		foreach ($subscribers as $subscriber) {
 			$dispatcher->addSetup('addSubscriber', [$subscriber]);
 		}
+
+		$this->registerAttributedListeners($dispatcher, lazy: false);
 	}
 
 	/**
@@ -131,52 +138,268 @@ class EventDispatcherExtension extends CompilerExtension
 		$subscribers = $builder->findByType(EventSubscriberInterface::class);
 		foreach ($subscribers as $serviceName => $subscriber) {
 			assert($subscriber instanceof ServiceDefinition);
-			$events = call_user_func([$subscriber->getEntity(), 'getSubscribedEvents']); // @phpstan-ignore-line
-			assert(is_array($events));
 
-			foreach ($events as $event => $params) {
-				if (is_string($params)) { // ['eventName' => 'methodName']
-					if (!method_exists((string) $subscriber->getType(), $params)) {
-						throw new ServiceCreationException(sprintf('Event listener %s does not have callable method %s', $subscriber->getType(), $params));
-					}
+			foreach ($this->resolveSubscriberListeners($subscriber) as $listener) {
+				$this->registerListener(
+					$dispatcher,
+					$serviceName,
+					$listener['eventName'],
+					$listener['methodName'],
+					$listener['priority'],
+					true,
+				);
+			}
+		}
 
-					$dispatcher->addSetup('addListener', [
-							'eventName' => $event,
-							'listener' => new Statement(LazyListener::class, [$serviceName, $params, $builder->getDefinitionByType(Container::class)]),
-							'priority' => 0,
-						]);
-				} elseif (is_array($params) && isset($params[0]) && is_string($params[0])) { // ['eventName' => ['methodName', $priority]]
-					$method = $params[0];
-					$priority = isset($params[1]) && is_int($params[1]) ? $params[1] : 0;
+		$this->registerAttributedListeners($dispatcher, lazy: true);
+	}
 
-					if (!method_exists((string) $subscriber->getType(), $method)) {
-						throw new ServiceCreationException(sprintf('Event listener %s does not have callable method %s', $subscriber->getType(), $method));
-					}
+	/**
+	 * @return list<array{eventName: string, methodName: string, priority: int}>
+	 */
+	private function resolveSubscriberListeners(ServiceDefinition $subscriber): array
+	{
+		$events = call_user_func([$subscriber->getEntity(), 'getSubscribedEvents']); // @phpstan-ignore-line
+		assert(is_array($events));
 
-					$dispatcher->addSetup('addListener', [
-							'eventName' => $event,
-							'listener' => new Statement(LazyListener::class, [$serviceName, $method, $builder->getDefinitionByType(Container::class)]),
-							'priority' => $priority,
-						]);
-				} elseif (is_array($params) && isset($params[0]) && is_array($params[0])) { // ['eventName' => [['methodName1', $priority], ['methodName2']]]
-					foreach ($params as $listener) {
-						assert(is_array($listener) && isset($listener[0]) && is_string($listener[0]));
-						$method = $listener[0];
-						$priority = isset($listener[1]) && is_int($listener[1]) ? $listener[1] : 0;
+		$listeners = [];
+		foreach ($events as $event => $params) {
+			if (is_string($params)) { // ['eventName' => 'methodName']
+				$this->assertListenerMethod((string) $subscriber->getType(), $params);
+				$listeners[] = [
+					'eventName' => $event,
+					'methodName' => $params,
+					'priority' => 0,
+				];
+			} elseif (is_array($params) && isset($params[0]) && is_string($params[0])) { // ['eventName' => ['methodName', $priority]]
+				$method = $params[0];
+				$priority = isset($params[1]) && is_int($params[1]) ? $params[1] : 0;
 
-						if (!method_exists((string) $subscriber->getType(), $method)) {
-							throw new ServiceCreationException(sprintf('Event listener %s does not have callable method %s', $subscriber->getType(), $method));
-						}
+				$this->assertListenerMethod((string) $subscriber->getType(), $method);
+				$listeners[] = [
+					'eventName' => $event,
+					'methodName' => $method,
+					'priority' => $priority,
+				];
+			} elseif (is_array($params) && isset($params[0]) && is_array($params[0])) { // ['eventName' => [['methodName1', $priority], ['methodName2']]]
+				foreach ($params as $listener) {
+					assert(is_array($listener) && isset($listener[0]) && is_string($listener[0]));
+					$method = $listener[0];
+					$priority = isset($listener[1]) && is_int($listener[1]) ? $listener[1] : 0;
 
-						$dispatcher->addSetup('addListener', [
-								'eventName' => $event,
-								'listener' => new Statement(LazyListener::class, [$serviceName, $method, $builder->getDefinitionByType(Container::class)]),
-								'priority' => $priority,
-							]);
-					}
+					$this->assertListenerMethod((string) $subscriber->getType(), $method);
+					$listeners[] = [
+						'eventName' => $event,
+						'methodName' => $method,
+						'priority' => $priority,
+					];
 				}
 			}
 		}
+
+		return $listeners;
+	}
+
+	private function registerAttributedListeners(ServiceDefinition $dispatcher, bool $lazy): void
+	{
+		foreach ($this->resolveAttributedListeners() as $listener) {
+			$this->registerListener(
+				$dispatcher,
+				$listener['serviceName'],
+				$listener['eventName'],
+				$listener['methodName'],
+				$listener['priority'],
+				$lazy,
+			);
+		}
+	}
+
+	private function registerListener(
+		ServiceDefinition $dispatcher,
+		string $serviceName,
+		string $eventName,
+		string $methodName,
+		int $priority,
+		bool $lazy,
+	): void
+	{
+		$builder = $this->getContainerBuilder();
+
+		$listener = $lazy
+			? new Statement(LazyListener::class, [$serviceName, $methodName, $builder->getDefinitionByType(Container::class)])
+			: [$builder->getDefinition($serviceName), $methodName];
+
+		$dispatcher->addSetup('addListener', [
+			'eventName' => $eventName,
+			'listener' => $listener,
+			'priority' => $priority,
+		]);
+	}
+
+	/**
+	 * @return list<array{serviceName: string, eventName: string, methodName: string, priority: int}>
+	 */
+	private function resolveAttributedListeners(): array
+	{
+		$builder = $this->getContainerBuilder();
+		$listeners = [];
+
+		foreach ($builder->getDefinitions() as $serviceName => $definition) {
+			if (!$definition instanceof ServiceDefinition) {
+				continue;
+			}
+
+			$className = $this->resolveDefinitionClass($definition);
+			if ($className === null) {
+				continue;
+			}
+
+			$reflection = new ReflectionClass($className);
+
+			foreach ($reflection->getAttributes(AsEventListener::class) as $attribute) {
+				$listeners[] = $this->resolveAttributedListener($serviceName, $reflection, null, $attribute->newInstance());
+			}
+
+			foreach ($reflection->getMethods() as $method) {
+				foreach ($method->getAttributes(AsEventListener::class) as $attribute) {
+					$listeners[] = $this->resolveAttributedListener($serviceName, $reflection, $method, $attribute->newInstance());
+				}
+			}
+		}
+
+		return $listeners;
+	}
+
+	/**
+	 * @return class-string|null
+	 */
+	private function resolveDefinitionClass(ServiceDefinition $definition): ?string
+	{
+		$type = $definition->getType();
+		if (is_string($type) && class_exists($type)) {
+			return $type;
+		}
+
+		$entity = $definition->getEntity();
+		if (is_string($entity) && class_exists($entity)) {
+			return $entity;
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param ReflectionClass<object> $reflection
+	 * @return array{serviceName: string, eventName: string, methodName: string, priority: int}
+	 */
+	private function resolveAttributedListener(
+		string $serviceName,
+		ReflectionClass $reflection,
+		?ReflectionMethod $method,
+		AsEventListener $attribute,
+	): array
+	{
+		if ($attribute->dispatcher !== null) {
+			throw new ServiceCreationException(sprintf(
+				'Event listener %s cannot use dispatcher in #[AsEventListener], named dispatchers are not supported.',
+				$reflection->getName(),
+			));
+		}
+
+		if ($method !== null && $attribute->method !== null) {
+			throw new ServiceCreationException(sprintf(
+				'Event listener %s::%s() cannot declare method in #[AsEventListener].',
+				$reflection->getName(),
+				$method->getName(),
+			));
+		}
+
+		$methodName = $method?->getName() ?? $this->resolveAttributedMethod($reflection, $attribute);
+		$this->assertListenerMethod($reflection->getName(), $methodName);
+
+		$eventName = $attribute->event ?? $this->inferAttributedEventName($reflection, $methodName);
+
+		return [
+			'serviceName' => $serviceName,
+			'eventName' => $eventName,
+			'methodName' => $methodName,
+			'priority' => $attribute->priority,
+		];
+	}
+
+	/**
+	 * @param ReflectionClass<object> $reflection
+	 */
+	private function resolveAttributedMethod(ReflectionClass $reflection, AsEventListener $attribute): string
+	{
+		if ($attribute->method !== null) {
+			return $attribute->method;
+		}
+
+		if ($attribute->event !== null) {
+			$method = $this->formatEventListenerMethod($attribute->event);
+			if ($reflection->hasMethod($method) && $reflection->getMethod($method)->isPublic()) {
+				return $method;
+			}
+		}
+
+		if ($reflection->hasMethod('__invoke') && $reflection->getMethod('__invoke')->isPublic()) {
+			return '__invoke';
+		}
+
+		throw new ServiceCreationException(sprintf(
+			'Event listener %s must define method in #[AsEventListener] or provide a public __invoke() handler.',
+			$reflection->getName(),
+		));
+	}
+
+	/**
+	 * @param ReflectionClass<object> $reflection
+	 */
+	private function inferAttributedEventName(ReflectionClass $reflection, string $methodName): string
+	{
+		$method = $reflection->getMethod($methodName);
+
+		if (
+			$method->getNumberOfParameters() < 1
+			|| !($type = $method->getParameters()[0]->getType()) instanceof ReflectionNamedType
+			|| $type->isBuiltin()
+			|| $type->getName() === Event::class
+		) {
+			throw new ServiceCreationException(sprintf(
+				'Event listener %s::%s() must define event in #[AsEventListener] or type its first argument with a concrete event class.',
+				$reflection->getName(),
+				$methodName,
+			));
+		}
+
+		return $type->getName();
+	}
+
+	private function assertListenerMethod(string $className, string $methodName): void
+	{
+		if (!method_exists($className, $methodName) || !(new ReflectionMethod($className, $methodName))->isPublic()) {
+			throw new ServiceCreationException(sprintf('Event listener %s does not have callable method %s', $className, $methodName));
+		}
+	}
+
+	private function formatEventListenerMethod(string $eventName): string
+	{
+		$method = preg_replace_callback(
+			['/(?<=\\b|_)[a-z]/i', '/[^a-z0-9]/i'],
+			static fn (array $matches): string => strtoupper($matches[0]),
+			$eventName,
+		);
+		if ($method === null) {
+			throw new ServiceCreationException(sprintf('Could not normalize event listener method for event %s', $eventName));
+		}
+
+		$normalized = preg_replace('/[^a-z0-9]/i', '', $method);
+		if ($normalized === null) {
+			throw new ServiceCreationException(sprintf('Could not normalize event listener method for event %s', $eventName));
+		}
+
+		return 'on' . $normalized;
 	}
 
 }

--- a/src/DI/EventDispatcherExtension.php
+++ b/src/DI/EventDispatcherExtension.php
@@ -71,9 +71,15 @@ class EventDispatcherExtension extends CompilerExtension
 	{
 		$config = $this->getConfig();
 
-		if ($config->autoload === true) {
-			$this->doBeforeCompile();
+		if ($config->autoload !== true) {
+			return;
 		}
+
+		$builder = $this->getContainerBuilder();
+		$dispatcher = $builder->getDefinition($this->prefix('dispatcher'));
+		assert($dispatcher instanceof ServiceDefinition);
+
+		BuilderMan::of($builder)->registerListeners($dispatcher);
 	}
 
 	public function afterCompile(ClassType $class): void
@@ -93,21 +99,6 @@ class EventDispatcherExtension extends CompilerExtension
 					]),
 				])
 			);
-		}
-	}
-
-	/**
-	 * Collect listeners and subscribers in lazy-way
-	 */
-	private function doBeforeCompile(): void
-	{
-		$builder = $this->getContainerBuilder();
-		$builderMan = BuilderMan::of($builder);
-		$dispatcher = $builder->getDefinition($this->prefix('dispatcher'));
-		assert($dispatcher instanceof ServiceDefinition);
-
-		foreach ($builderMan->getListeners() as $listener) {
-			$builderMan->registerListener($dispatcher, $listener);
 		}
 	}
 

--- a/src/DI/EventDispatcherExtension.php
+++ b/src/DI/EventDispatcherExtension.php
@@ -2,27 +2,19 @@
 
 namespace Contributte\EventDispatcher\DI;
 
+use Contributte\EventDispatcher\DI\Utils\BuilderMan;
 use Contributte\EventDispatcher\Diagnostics\DebugDispatcher;
 use Contributte\EventDispatcher\Diagnostics\TracyDispatcher;
-use Contributte\EventDispatcher\LazyListener;
 use Contributte\EventDispatcher\Tracy\EventPanel;
 use Nette\DI\CompilerExtension;
-use Nette\DI\Container;
 use Nette\DI\Definitions\ServiceDefinition;
 use Nette\DI\Definitions\Statement;
-use Nette\DI\ServiceCreationException;
 use Nette\PhpGenerator\ClassType;
 use Nette\Schema\Expect;
 use Nette\Schema\Schema;
-use ReflectionClass;
-use ReflectionMethod;
-use ReflectionNamedType;
 use stdClass;
-use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Contracts\EventDispatcher\Event;
 use Tracy\Bar;
 
 /**
@@ -115,15 +107,17 @@ class EventDispatcherExtension extends CompilerExtension
 	private function doBeforeCompile(): void
 	{
 		$builder = $this->getContainerBuilder();
+		$builderMan = BuilderMan::of($builder);
 		$dispatcher = $builder->getDefinition($this->prefix('dispatcher'));
 		assert($dispatcher instanceof ServiceDefinition);
 
-		$subscribers = $builder->findByType(EventSubscriberInterface::class);
-		foreach ($subscribers as $subscriber) {
+		foreach ($builderMan->getSubscribers() as $subscriber) {
 			$dispatcher->addSetup('addSubscriber', [$subscriber]);
 		}
 
-		$this->registerAttributedListeners($dispatcher, lazy: false);
+		foreach ($builderMan->getAttributedListeners() as $listener) {
+			$builderMan->registerListener($dispatcher, $listener, lazy: false);
+		}
 	}
 
 	/**
@@ -132,274 +126,17 @@ class EventDispatcherExtension extends CompilerExtension
 	private function doBeforeCompileLaziness(): void
 	{
 		$builder = $this->getContainerBuilder();
+		$builderMan = BuilderMan::of($builder);
 		$dispatcher = $builder->getDefinition($this->prefix('dispatcher'));
 		assert($dispatcher instanceof ServiceDefinition);
 
-		$subscribers = $builder->findByType(EventSubscriberInterface::class);
-		foreach ($subscribers as $serviceName => $subscriber) {
-			assert($subscriber instanceof ServiceDefinition);
-
-			foreach ($this->resolveSubscriberListeners($subscriber) as $listener) {
-				$this->registerListener(
-					$dispatcher,
-					$serviceName,
-					$listener['eventName'],
-					$listener['methodName'],
-					$listener['priority'],
-					true,
-				);
-			}
+		foreach ($builderMan->getSubscriberListeners() as $listener) {
+			$builderMan->registerListener($dispatcher, $listener, lazy: true);
 		}
 
-		$this->registerAttributedListeners($dispatcher, lazy: true);
-	}
-
-	/**
-	 * @return list<array{eventName: string, methodName: string, priority: int}>
-	 */
-	private function resolveSubscriberListeners(ServiceDefinition $subscriber): array
-	{
-		$events = call_user_func([$subscriber->getEntity(), 'getSubscribedEvents']); // @phpstan-ignore-line
-		assert(is_array($events));
-
-		$listeners = [];
-		foreach ($events as $event => $params) {
-			if (is_string($params)) { // ['eventName' => 'methodName']
-				$this->assertListenerMethod((string) $subscriber->getType(), $params);
-				$listeners[] = [
-					'eventName' => $event,
-					'methodName' => $params,
-					'priority' => 0,
-				];
-			} elseif (is_array($params) && isset($params[0]) && is_string($params[0])) { // ['eventName' => ['methodName', $priority]]
-				$method = $params[0];
-				$priority = isset($params[1]) && is_int($params[1]) ? $params[1] : 0;
-
-				$this->assertListenerMethod((string) $subscriber->getType(), $method);
-				$listeners[] = [
-					'eventName' => $event,
-					'methodName' => $method,
-					'priority' => $priority,
-				];
-			} elseif (is_array($params) && isset($params[0]) && is_array($params[0])) { // ['eventName' => [['methodName1', $priority], ['methodName2']]]
-				foreach ($params as $listener) {
-					assert(is_array($listener) && isset($listener[0]) && is_string($listener[0]));
-					$method = $listener[0];
-					$priority = isset($listener[1]) && is_int($listener[1]) ? $listener[1] : 0;
-
-					$this->assertListenerMethod((string) $subscriber->getType(), $method);
-					$listeners[] = [
-						'eventName' => $event,
-						'methodName' => $method,
-						'priority' => $priority,
-					];
-				}
-			}
+		foreach ($builderMan->getAttributedListeners() as $listener) {
+			$builderMan->registerListener($dispatcher, $listener, lazy: true);
 		}
-
-		return $listeners;
-	}
-
-	private function registerAttributedListeners(ServiceDefinition $dispatcher, bool $lazy): void
-	{
-		foreach ($this->resolveAttributedListeners() as $listener) {
-			$this->registerListener(
-				$dispatcher,
-				$listener['serviceName'],
-				$listener['eventName'],
-				$listener['methodName'],
-				$listener['priority'],
-				$lazy,
-			);
-		}
-	}
-
-	private function registerListener(
-		ServiceDefinition $dispatcher,
-		string $serviceName,
-		string $eventName,
-		string $methodName,
-		int $priority,
-		bool $lazy,
-	): void
-	{
-		$builder = $this->getContainerBuilder();
-
-		$listener = $lazy
-			? new Statement(LazyListener::class, [$serviceName, $methodName, $builder->getDefinitionByType(Container::class)])
-			: [$builder->getDefinition($serviceName), $methodName];
-
-		$dispatcher->addSetup('addListener', [
-			'eventName' => $eventName,
-			'listener' => $listener,
-			'priority' => $priority,
-		]);
-	}
-
-	/**
-	 * @return list<array{serviceName: string, eventName: string, methodName: string, priority: int}>
-	 */
-	private function resolveAttributedListeners(): array
-	{
-		$builder = $this->getContainerBuilder();
-		$listeners = [];
-
-		foreach ($builder->getDefinitions() as $serviceName => $definition) {
-			if (!$definition instanceof ServiceDefinition) {
-				continue;
-			}
-
-			$className = $this->resolveDefinitionClass($definition);
-			if ($className === null) {
-				continue;
-			}
-
-			$reflection = new ReflectionClass($className);
-
-			foreach ($reflection->getAttributes(AsEventListener::class) as $attribute) {
-				$listeners[] = $this->resolveAttributedListener($serviceName, $reflection, null, $attribute->newInstance());
-			}
-
-			foreach ($reflection->getMethods() as $method) {
-				foreach ($method->getAttributes(AsEventListener::class) as $attribute) {
-					$listeners[] = $this->resolveAttributedListener($serviceName, $reflection, $method, $attribute->newInstance());
-				}
-			}
-		}
-
-		return $listeners;
-	}
-
-	/**
-	 * @return class-string|null
-	 */
-	private function resolveDefinitionClass(ServiceDefinition $definition): ?string
-	{
-		$type = $definition->getType();
-		if (is_string($type) && class_exists($type)) {
-			return $type;
-		}
-
-		$entity = $definition->getEntity();
-		if (is_string($entity) && class_exists($entity)) {
-			return $entity;
-		}
-
-		return null;
-	}
-
-	/**
-	 * @param ReflectionClass<object> $reflection
-	 * @return array{serviceName: string, eventName: string, methodName: string, priority: int}
-	 */
-	private function resolveAttributedListener(
-		string $serviceName,
-		ReflectionClass $reflection,
-		?ReflectionMethod $method,
-		AsEventListener $attribute,
-	): array
-	{
-		if ($attribute->dispatcher !== null) {
-			throw new ServiceCreationException(sprintf(
-				'Event listener %s cannot use dispatcher in #[AsEventListener], named dispatchers are not supported.',
-				$reflection->getName(),
-			));
-		}
-
-		if ($method !== null && $attribute->method !== null) {
-			throw new ServiceCreationException(sprintf(
-				'Event listener %s::%s() cannot declare method in #[AsEventListener].',
-				$reflection->getName(),
-				$method->getName(),
-			));
-		}
-
-		$methodName = $method?->getName() ?? $this->resolveAttributedMethod($reflection, $attribute);
-		$this->assertListenerMethod($reflection->getName(), $methodName);
-
-		$eventName = $attribute->event ?? $this->inferAttributedEventName($reflection, $methodName);
-
-		return [
-			'serviceName' => $serviceName,
-			'eventName' => $eventName,
-			'methodName' => $methodName,
-			'priority' => $attribute->priority,
-		];
-	}
-
-	/**
-	 * @param ReflectionClass<object> $reflection
-	 */
-	private function resolveAttributedMethod(ReflectionClass $reflection, AsEventListener $attribute): string
-	{
-		if ($attribute->method !== null) {
-			return $attribute->method;
-		}
-
-		if ($attribute->event !== null) {
-			$method = $this->formatEventListenerMethod($attribute->event);
-			if ($reflection->hasMethod($method) && $reflection->getMethod($method)->isPublic()) {
-				return $method;
-			}
-		}
-
-		if ($reflection->hasMethod('__invoke') && $reflection->getMethod('__invoke')->isPublic()) {
-			return '__invoke';
-		}
-
-		throw new ServiceCreationException(sprintf(
-			'Event listener %s must define method in #[AsEventListener] or provide a public __invoke() handler.',
-			$reflection->getName(),
-		));
-	}
-
-	/**
-	 * @param ReflectionClass<object> $reflection
-	 */
-	private function inferAttributedEventName(ReflectionClass $reflection, string $methodName): string
-	{
-		$method = $reflection->getMethod($methodName);
-
-		if (
-			$method->getNumberOfParameters() < 1
-			|| !($type = $method->getParameters()[0]->getType()) instanceof ReflectionNamedType
-			|| $type->isBuiltin()
-			|| $type->getName() === Event::class
-		) {
-			throw new ServiceCreationException(sprintf(
-				'Event listener %s::%s() must define event in #[AsEventListener] or type its first argument with a concrete event class.',
-				$reflection->getName(),
-				$methodName,
-			));
-		}
-
-		return $type->getName();
-	}
-
-	private function assertListenerMethod(string $className, string $methodName): void
-	{
-		if (!method_exists($className, $methodName) || !(new ReflectionMethod($className, $methodName))->isPublic()) {
-			throw new ServiceCreationException(sprintf('Event listener %s does not have callable method %s', $className, $methodName));
-		}
-	}
-
-	private function formatEventListenerMethod(string $eventName): string
-	{
-		$method = preg_replace_callback(
-			['/(?<=\\b|_)[a-z]/i', '/[^a-z0-9]/i'],
-			static fn (array $matches): string => strtoupper($matches[0]),
-			$eventName,
-		);
-		if ($method === null) {
-			throw new ServiceCreationException(sprintf('Could not normalize event listener method for event %s', $eventName));
-		}
-
-		$normalized = preg_replace('/[^a-z0-9]/i', '', $method);
-		if ($normalized === null) {
-			throw new ServiceCreationException(sprintf('Could not normalize event listener method for event %s', $eventName));
-		}
-
-		return 'on' . $normalized;
 	}
 
 }

--- a/src/DI/EventDispatcherExtension.php
+++ b/src/DI/EventDispatcherExtension.php
@@ -26,7 +26,6 @@ class EventDispatcherExtension extends CompilerExtension
 	public function getConfigSchema(): Schema
 	{
 		return Expect::structure([
-			'lazy' => Expect::bool(true),
 			'autoload' => Expect::bool(true),
 			'debug' => Expect::structure([
 				'panel' => Expect::bool(false),
@@ -73,11 +72,7 @@ class EventDispatcherExtension extends CompilerExtension
 		$config = $this->getConfig();
 
 		if ($config->autoload === true) {
-			if ($config->lazy === true) {
-				$this->doBeforeCompileLaziness();
-			} else {
-				$this->doBeforeCompile();
-			}
+			$this->doBeforeCompile();
 		}
 	}
 
@@ -102,7 +97,7 @@ class EventDispatcherExtension extends CompilerExtension
 	}
 
 	/**
-	 * Collect listeners and subscribers
+	 * Collect listeners and subscribers in lazy-way
 	 */
 	private function doBeforeCompile(): void
 	{
@@ -111,31 +106,12 @@ class EventDispatcherExtension extends CompilerExtension
 		$dispatcher = $builder->getDefinition($this->prefix('dispatcher'));
 		assert($dispatcher instanceof ServiceDefinition);
 
-		foreach ($builderMan->getSubscribers() as $subscriber) {
-			$dispatcher->addSetup('addSubscriber', [$subscriber]);
-		}
-
-		foreach ($builderMan->getAttributedListeners() as $listener) {
-			$builderMan->registerListener($dispatcher, $listener, lazy: false);
-		}
-	}
-
-	/**
-	 * Collect listeners and subscribers in lazy-way
-	 */
-	private function doBeforeCompileLaziness(): void
-	{
-		$builder = $this->getContainerBuilder();
-		$builderMan = BuilderMan::of($builder);
-		$dispatcher = $builder->getDefinition($this->prefix('dispatcher'));
-		assert($dispatcher instanceof ServiceDefinition);
-
 		foreach ($builderMan->getSubscriberListeners() as $listener) {
-			$builderMan->registerListener($dispatcher, $listener, lazy: true);
+			$builderMan->registerListener($dispatcher, $listener);
 		}
 
 		foreach ($builderMan->getAttributedListeners() as $listener) {
-			$builderMan->registerListener($dispatcher, $listener, lazy: true);
+			$builderMan->registerListener($dispatcher, $listener);
 		}
 	}
 

--- a/src/DI/EventDispatcherExtension.php
+++ b/src/DI/EventDispatcherExtension.php
@@ -106,11 +106,7 @@ class EventDispatcherExtension extends CompilerExtension
 		$dispatcher = $builder->getDefinition($this->prefix('dispatcher'));
 		assert($dispatcher instanceof ServiceDefinition);
 
-		foreach ($builderMan->getSubscriberListeners() as $listener) {
-			$builderMan->registerListener($dispatcher, $listener);
-		}
-
-		foreach ($builderMan->getAttributedListeners() as $listener) {
+		foreach ($builderMan->getListeners() as $listener) {
 			$builderMan->registerListener($dispatcher, $listener);
 		}
 	}

--- a/src/DI/Utils/BuilderMan.php
+++ b/src/DI/Utils/BuilderMan.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\EventDispatcher\DI\Utils;
+
+use Contributte\EventDispatcher\LazyListener;
+use Nette\DI\Container;
+use Nette\DI\ContainerBuilder;
+use Nette\DI\Definitions\ServiceDefinition;
+use Nette\DI\Definitions\Statement;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class BuilderMan
+{
+
+	private function __construct(private readonly ContainerBuilder $builder)
+	{
+	}
+
+	public static function of(ContainerBuilder $builder): self
+	{
+		return new self($builder);
+	}
+
+	/**
+	 * @return array<string, ServiceDefinition>
+	 */
+	public function getSubscribers(): array
+	{
+		/** @var array<string, ServiceDefinition> $subscribers */
+		$subscribers = $this->builder->findByType(EventSubscriberInterface::class);
+
+		return $subscribers;
+	}
+
+	/**
+	 * @return list<ListenerDefinition>
+	 */
+	public function getSubscriberListeners(): array
+	{
+		$listeners = [];
+
+		foreach ($this->getSubscribers() as $serviceName => $subscriber) {
+			$className = $this->getDefinitionClass($subscriber);
+			if ($className === null || !is_a($className, EventSubscriberInterface::class, true)) {
+				continue;
+			}
+
+			array_push($listeners, ...Reflector::getSubscriberListeners($serviceName, $className));
+		}
+
+		return $listeners;
+	}
+
+	/**
+	 * @return list<ListenerDefinition>
+	 */
+	public function getAttributedListeners(): array
+	{
+		$listeners = [];
+
+		foreach ($this->builder->getDefinitions() as $serviceName => $definition) {
+			if (!$definition instanceof ServiceDefinition) {
+				continue;
+			}
+
+			$className = $this->getDefinitionClass($definition);
+			if ($className === null) {
+				continue;
+			}
+
+			array_push($listeners, ...Reflector::getAttributedListeners($serviceName, $className));
+		}
+
+		return $listeners;
+	}
+
+	public function registerListener(ServiceDefinition $dispatcher, ListenerDefinition $listener, bool $lazy): void
+	{
+		$callable = $lazy
+			? new Statement(LazyListener::class, [$listener->serviceName, $listener->methodName, $this->builder->getDefinitionByType(Container::class)])
+			: [$this->builder->getDefinition($listener->serviceName), $listener->methodName];
+
+		$dispatcher->addSetup('addListener', [
+			'eventName' => $listener->eventName,
+			'listener' => $callable,
+			'priority' => $listener->priority,
+		]);
+	}
+
+	/**
+	 * @return class-string|null
+	 */
+	private function getDefinitionClass(ServiceDefinition $definition): ?string
+	{
+		$type = $definition->getType();
+		if (is_string($type) && class_exists($type)) {
+			return $type;
+		}
+
+		$entity = $definition->getEntity();
+		if (is_string($entity) && class_exists($entity)) {
+			return $entity;
+		}
+
+		return null;
+	}
+
+}

--- a/src/DI/Utils/BuilderMan.php
+++ b/src/DI/Utils/BuilderMan.php
@@ -24,17 +24,40 @@ final class BuilderMan
 	/**
 	 * @return list<ListenerDefinition>
 	 */
-	public function getSubscriberListeners(): array
+	public function getListeners(): array
+	{
+		return [
+			...$this->getSubscriberListeners(),
+			...$this->getAttributedListeners(),
+		];
+	}
+
+	public function registerListener(ServiceDefinition $dispatcher, ListenerDefinition $listener): void
+	{
+		$dispatcher->addSetup('addListener', [
+			'eventName' => $listener->eventName,
+			'listener' => new Statement(LazyListener::class, [$listener->serviceName, $listener->methodName, $this->builder->getDefinitionByType(Container::class)]),
+			'priority' => $listener->priority,
+		]);
+	}
+
+	/**
+	 * @return list<ListenerDefinition>
+	 */
+	private function getSubscriberListeners(): array
 	{
 		$listeners = [];
 
-		foreach ($this->getSubscribers() as $serviceName => $subscriber) {
+		/** @var array<string, ServiceDefinition> $subscribers */
+		$subscribers = $this->builder->findByType(EventSubscriberInterface::class);
+
+		foreach ($subscribers as $serviceName => $subscriber) {
 			$className = $this->getDefinitionClass($subscriber);
 			if ($className === null || !is_a($className, EventSubscriberInterface::class, true)) {
 				continue;
 			}
 
-			array_push($listeners, ...Reflector::getSubscriberListeners($serviceName, $className));
+			$listeners = [...$listeners, ...Reflector::getSubscriberListeners($serviceName, $className)];
 		}
 
 		return $listeners;
@@ -43,7 +66,7 @@ final class BuilderMan
 	/**
 	 * @return list<ListenerDefinition>
 	 */
-	public function getAttributedListeners(): array
+	private function getAttributedListeners(): array
 	{
 		$listeners = [];
 
@@ -57,30 +80,10 @@ final class BuilderMan
 				continue;
 			}
 
-			array_push($listeners, ...Reflector::getAttributedListeners($serviceName, $className));
+			$listeners = [...$listeners, ...Reflector::getAttributedListeners($serviceName, $className)];
 		}
 
 		return $listeners;
-	}
-
-	public function registerListener(ServiceDefinition $dispatcher, ListenerDefinition $listener): void
-	{
-		$dispatcher->addSetup('addListener', [
-			'eventName' => $listener->eventName,
-			'listener' => new Statement(LazyListener::class, [$listener->serviceName, $listener->methodName, $this->builder->getDefinitionByType(Container::class)]),
-			'priority' => $listener->priority,
-		]);
-	}
-
-	/**
-	 * @return array<string, ServiceDefinition>
-	 */
-	private function getSubscribers(): array
-	{
-		/** @var array<string, ServiceDefinition> $subscribers */
-		$subscribers = $this->builder->findByType(EventSubscriberInterface::class);
-
-		return $subscribers;
 	}
 
 	/**
@@ -89,13 +92,8 @@ final class BuilderMan
 	private function getDefinitionClass(ServiceDefinition $definition): ?string
 	{
 		$type = $definition->getType();
-		if (is_string($type) && class_exists($type)) {
+		if ($type !== null && class_exists($type)) {
 			return $type;
-		}
-
-		$entity = $definition->getEntity();
-		if (is_string($entity) && class_exists($entity)) {
-			return $entity;
 		}
 
 		return null;

--- a/src/DI/Utils/BuilderMan.php
+++ b/src/DI/Utils/BuilderMan.php
@@ -21,24 +21,28 @@ final class BuilderMan
 		return new self($builder);
 	}
 
+	public function registerListeners(ServiceDefinition $dispatcher): void
+	{
+		$container = $this->builder->getDefinitionByType(Container::class);
+
+		foreach ($this->getListeners() as $listener) {
+			$dispatcher->addSetup('addListener', [
+				'eventName' => $listener->eventName,
+				'listener' => new Statement(LazyListener::class, [$listener->serviceName, $listener->methodName, $container]),
+				'priority' => $listener->priority,
+			]);
+		}
+	}
+
 	/**
 	 * @return list<ListenerDefinition>
 	 */
-	public function getListeners(): array
+	private function getListeners(): array
 	{
 		return [
 			...$this->getSubscriberListeners(),
 			...$this->getAttributedListeners(),
 		];
-	}
-
-	public function registerListener(ServiceDefinition $dispatcher, ListenerDefinition $listener): void
-	{
-		$dispatcher->addSetup('addListener', [
-			'eventName' => $listener->eventName,
-			'listener' => new Statement(LazyListener::class, [$listener->serviceName, $listener->methodName, $this->builder->getDefinitionByType(Container::class)]),
-			'priority' => $listener->priority,
-		]);
 	}
 
 	/**

--- a/src/DI/Utils/BuilderMan.php
+++ b/src/DI/Utils/BuilderMan.php
@@ -22,17 +22,6 @@ final class BuilderMan
 	}
 
 	/**
-	 * @return array<string, ServiceDefinition>
-	 */
-	public function getSubscribers(): array
-	{
-		/** @var array<string, ServiceDefinition> $subscribers */
-		$subscribers = $this->builder->findByType(EventSubscriberInterface::class);
-
-		return $subscribers;
-	}
-
-	/**
 	 * @return list<ListenerDefinition>
 	 */
 	public function getSubscriberListeners(): array
@@ -74,17 +63,24 @@ final class BuilderMan
 		return $listeners;
 	}
 
-	public function registerListener(ServiceDefinition $dispatcher, ListenerDefinition $listener, bool $lazy): void
+	public function registerListener(ServiceDefinition $dispatcher, ListenerDefinition $listener): void
 	{
-		$callable = $lazy
-			? new Statement(LazyListener::class, [$listener->serviceName, $listener->methodName, $this->builder->getDefinitionByType(Container::class)])
-			: [$this->builder->getDefinition($listener->serviceName), $listener->methodName];
-
 		$dispatcher->addSetup('addListener', [
 			'eventName' => $listener->eventName,
-			'listener' => $callable,
+			'listener' => new Statement(LazyListener::class, [$listener->serviceName, $listener->methodName, $this->builder->getDefinitionByType(Container::class)]),
 			'priority' => $listener->priority,
 		]);
+	}
+
+	/**
+	 * @return array<string, ServiceDefinition>
+	 */
+	private function getSubscribers(): array
+	{
+		/** @var array<string, ServiceDefinition> $subscribers */
+		$subscribers = $this->builder->findByType(EventSubscriberInterface::class);
+
+		return $subscribers;
 	}
 
 	/**

--- a/src/DI/Utils/ListenerDefinition.php
+++ b/src/DI/Utils/ListenerDefinition.php
@@ -2,14 +2,14 @@
 
 namespace Contributte\EventDispatcher\DI\Utils;
 
-final class ListenerDefinition
+final readonly class ListenerDefinition
 {
 
 	public function __construct(
-		public readonly string $serviceName,
-		public readonly string $eventName,
-		public readonly string $methodName,
-		public readonly int $priority,
+		public string $serviceName,
+		public string $eventName,
+		public string $methodName,
+		public int $priority,
 	)
 	{
 	}

--- a/src/DI/Utils/ListenerDefinition.php
+++ b/src/DI/Utils/ListenerDefinition.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\EventDispatcher\DI\Utils;
+
+final class ListenerDefinition
+{
+
+	public function __construct(
+		public readonly string $serviceName,
+		public readonly string $eventName,
+		public readonly string $methodName,
+		public readonly int $priority,
+	)
+	{
+	}
+
+}

--- a/src/DI/Utils/Reflector.php
+++ b/src/DI/Utils/Reflector.php
@@ -1,0 +1,196 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\EventDispatcher\DI\Utils;
+
+use Nette\DI\ServiceCreationException;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class Reflector
+{
+
+	/**
+	 * @param class-string<EventSubscriberInterface> $className
+	 * @return list<ListenerDefinition>
+	 */
+	public static function getSubscriberListeners(string $serviceName, string $className): array
+	{
+		$events = self::getSubscribedEvents($className);
+
+		$listeners = [];
+		foreach ($events as $event => $params) {
+			if (is_string($params)) { // ['eventName' => 'methodName']
+				self::assertListenerMethod($className, $params);
+				$listeners[] = new ListenerDefinition($serviceName, $event, $params, 0);
+			} elseif (is_array($params) && isset($params[0]) && is_string($params[0])) { // ['eventName' => ['methodName', $priority]]
+				$method = $params[0];
+				$priority = isset($params[1]) && is_int($params[1]) ? $params[1] : 0;
+
+				self::assertListenerMethod($className, $method);
+				$listeners[] = new ListenerDefinition($serviceName, $event, $method, $priority);
+			} elseif (is_array($params) && isset($params[0]) && is_array($params[0])) { // ['eventName' => [['methodName1', $priority], ['methodName2']]]
+				foreach ($params as $listener) {
+					assert(is_array($listener) && isset($listener[0]) && is_string($listener[0]));
+					$method = $listener[0];
+					$priority = isset($listener[1]) && is_int($listener[1]) ? $listener[1] : 0;
+
+					self::assertListenerMethod($className, $method);
+					$listeners[] = new ListenerDefinition($serviceName, $event, $method, $priority);
+				}
+			}
+		}
+
+		return $listeners;
+	}
+
+	/**
+	 * @param class-string $className
+	 * @return list<ListenerDefinition>
+	 */
+	public static function getAttributedListeners(string $serviceName, string $className): array
+	{
+		$reflection = new ReflectionClass($className);
+		$listeners = [];
+
+		foreach ($reflection->getAttributes(AsEventListener::class) as $attribute) {
+			$listeners[] = self::resolveAttributedListener($serviceName, $reflection, null, $attribute);
+		}
+
+		foreach ($reflection->getMethods() as $method) {
+			foreach ($method->getAttributes(AsEventListener::class) as $attribute) {
+				$listeners[] = self::resolveAttributedListener($serviceName, $reflection, $method, $attribute);
+			}
+		}
+
+		return $listeners;
+	}
+
+	/**
+	 * @param class-string<EventSubscriberInterface> $className
+	 * @return array<mixed>
+	 */
+	private static function getSubscribedEvents(string $className): array
+	{
+		return $className::getSubscribedEvents();
+	}
+
+	/**
+	 * @param ReflectionClass<object> $reflection
+	 * @param ReflectionAttribute<AsEventListener> $attribute
+	 */
+	private static function resolveAttributedListener(
+		string $serviceName,
+		ReflectionClass $reflection,
+		?ReflectionMethod $method,
+		ReflectionAttribute $attribute,
+	): ListenerDefinition
+	{
+		$listener = $attribute->newInstance();
+
+		if ($listener->dispatcher !== null) {
+			throw new ServiceCreationException(sprintf(
+				'Event listener %s cannot use dispatcher in #[AsEventListener], named dispatchers are not supported.',
+				$reflection->getName(),
+			));
+		}
+
+		if ($method !== null && $listener->method !== null) {
+			throw new ServiceCreationException(sprintf(
+				'Event listener %s::%s() cannot declare method in #[AsEventListener].',
+				$reflection->getName(),
+				$method->getName(),
+			));
+		}
+
+		$methodName = $method?->getName() ?? self::resolveAttributedMethod($reflection, $listener);
+		self::assertListenerMethod($reflection->getName(), $methodName);
+
+		$eventName = $listener->event ?? self::inferAttributedEventName($reflection, $methodName);
+
+		return new ListenerDefinition($serviceName, $eventName, $methodName, $listener->priority);
+	}
+
+	/**
+	 * @param ReflectionClass<object> $reflection
+	 */
+	private static function resolveAttributedMethod(ReflectionClass $reflection, AsEventListener $listener): string
+	{
+		if ($listener->method !== null) {
+			return $listener->method;
+		}
+
+		if ($listener->event !== null) {
+			$method = self::formatEventListenerMethod($listener->event);
+			if ($reflection->hasMethod($method) && $reflection->getMethod($method)->isPublic()) {
+				return $method;
+			}
+		}
+
+		if ($reflection->hasMethod('__invoke') && $reflection->getMethod('__invoke')->isPublic()) {
+			return '__invoke';
+		}
+
+		throw new ServiceCreationException(sprintf(
+			'Event listener %s must define method in #[AsEventListener] or provide a public __invoke() handler.',
+			$reflection->getName(),
+		));
+	}
+
+	/**
+	 * @param ReflectionClass<object> $reflection
+	 */
+	private static function inferAttributedEventName(ReflectionClass $reflection, string $methodName): string
+	{
+		$method = $reflection->getMethod($methodName);
+
+		if (
+			$method->getNumberOfParameters() < 1
+			|| !($type = $method->getParameters()[0]->getType()) instanceof ReflectionNamedType
+			|| $type->isBuiltin()
+			|| $type->getName() === Event::class
+		) {
+			throw new ServiceCreationException(sprintf(
+				'Event listener %s::%s() must define event in #[AsEventListener] or type its first argument with a concrete event class.',
+				$reflection->getName(),
+				$methodName,
+			));
+		}
+
+		return $type->getName();
+	}
+
+	/**
+	 * @param class-string $className
+	 */
+	private static function assertListenerMethod(string $className, string $methodName): void
+	{
+		if (!method_exists($className, $methodName) || !(new ReflectionMethod($className, $methodName))->isPublic()) {
+			throw new ServiceCreationException(sprintf('Event listener %s does not have callable method %s', $className, $methodName));
+		}
+	}
+
+	private static function formatEventListenerMethod(string $eventName): string
+	{
+		$method = preg_replace_callback(
+			['/(?<=\\b|_)[a-z]/i', '/[^a-z0-9]/i'],
+			static fn (array $matches): string => strtoupper($matches[0]),
+			$eventName,
+		);
+		if ($method === null) {
+			throw new ServiceCreationException(sprintf('Could not normalize event listener method for event %s', $eventName));
+		}
+
+		$normalized = preg_replace('/[^a-z0-9]/i', '', $method);
+		if ($normalized === null) {
+			throw new ServiceCreationException(sprintf('Could not normalize event listener method for event %s', $eventName));
+		}
+
+		return 'on' . $normalized;
+	}
+
+}

--- a/src/DI/Utils/Reflector.php
+++ b/src/DI/Utils/Reflector.php
@@ -91,24 +91,25 @@ final class Reflector
 	): ListenerDefinition
 	{
 		$listener = $attribute->newInstance();
+		$className = $reflection->getName();
 
 		if ($listener->dispatcher !== null) {
 			throw new ServiceCreationException(sprintf(
 				'Event listener %s cannot use dispatcher in #[AsEventListener], named dispatchers are not supported.',
-				$reflection->getName(),
+				$className,
 			));
 		}
 
 		if ($method !== null && $listener->method !== null) {
 			throw new ServiceCreationException(sprintf(
 				'Event listener %s::%s() cannot declare method in #[AsEventListener].',
-				$reflection->getName(),
+				$className,
 				$method->getName(),
 			));
 		}
 
 		$methodName = $method?->getName() ?? self::resolveAttributedMethod($reflection, $listener);
-		self::assertListenerMethod($reflection->getName(), $methodName);
+		self::assertListenerMethod($className, $methodName);
 
 		$eventName = $listener->event ?? self::inferAttributedEventName($reflection, $methodName);
 

--- a/tests/Cases/DI/EventExtension.listener.phpt
+++ b/tests/Cases/DI/EventExtension.listener.phpt
@@ -125,35 +125,6 @@ Toolkit::test(function (): void {
 	Assert::equal([$typedEvent], $invokableListener->onCall);
 });
 
-// Register listeners eagerly when lazy loading is disabled.
-Toolkit::test(function (): void {
-	$container = ContainerBuilder::of()
-		->withCompiler(function (Compiler $compiler): void {
-			$compiler->addExtension('events', new EventDispatcherExtension());
-			$compiler->addConfig(Neonkit::load(<<<'NEON'
-				events:
-					lazy: false
-				services:
-					listener: Tests\Fixtures\MethodAttributedListener
-			NEON
-			));
-		})->build();
-
-	Assert::false($container->isCreated('listener'));
-
-	/** @var EventDispatcherInterface $em */
-	$em = $container->getByType(EventDispatcherInterface::class);
-
-	Assert::true($container->isCreated('listener'));
-
-	$event = new Event();
-	$em->dispatch($event, 'listener.method');
-
-	/** @var MethodAttributedListener $listener */
-	$listener = $container->getByType(MethodAttributedListener::class);
-	Assert::equal([$event], $listener->onMethodCall);
-});
-
 // Do not autoload attribute listeners when disabled.
 Toolkit::test(function (): void {
 	$container = ContainerBuilder::of()

--- a/tests/Cases/DI/EventExtension.listener.phpt
+++ b/tests/Cases/DI/EventExtension.listener.phpt
@@ -1,0 +1,233 @@
+<?php declare(strict_types = 1);
+
+use Contributte\EventDispatcher\DI\EventDispatcherExtension;
+use Contributte\Tester\Toolkit;
+use Contributte\Tester\Utils\ContainerBuilder;
+use Contributte\Tester\Utils\Neonkit;
+use Nette\DI\Compiler;
+use Nette\DI\ServiceCreationException;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+use Tester\Assert;
+use Tests\Fixtures\ClassAttributedListener;
+use Tests\Fixtures\InferredMethodAttributedListener;
+use Tests\Fixtures\InvokableAttributedListener;
+use Tests\Fixtures\MethodAttributedListener;
+use Tests\Fixtures\TypedEvent;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+// Register method-level listeners lazily by default.
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('events', new EventDispatcherExtension());
+			$compiler->addConfig(Neonkit::load(<<<'NEON'
+				services:
+					listener: Tests\Fixtures\MethodAttributedListener
+			NEON
+			));
+		})->build();
+
+	/** @var EventDispatcherInterface $em */
+	$em = $container->getByType(EventDispatcherInterface::class);
+
+	Assert::false($container->isCreated('listener'));
+	Assert::true($em->hasListeners('listener.method'));
+
+	$listeners = $em->getListeners('listener.method');
+	Assert::count(1, $listeners);
+	Assert::same(5, $em->getListenerPriority('listener.method', $listeners[0]));
+
+	$event = new Event();
+	$em->dispatch($event, 'listener.method');
+
+	Assert::true($container->isCreated('listener'));
+
+	/** @var MethodAttributedListener $listener */
+	$listener = $container->getByType(MethodAttributedListener::class);
+	Assert::equal([$event], $listener->onMethodCall);
+});
+
+// Infer typed events and register repeatable method attributes.
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('events', new EventDispatcherExtension());
+			$compiler->addConfig(Neonkit::load(<<<'NEON'
+				services:
+					listener: Tests\Fixtures\MethodAttributedListener
+			NEON
+			));
+		})->build();
+
+	/** @var EventDispatcherInterface $em */
+	$em = $container->getByType(EventDispatcherInterface::class);
+
+	Assert::true($em->hasListeners(TypedEvent::class));
+	Assert::count(1, $em->getListeners('listener.repeat.one'));
+	Assert::count(1, $em->getListeners('listener.repeat.two'));
+
+	$typedEvent = new TypedEvent();
+	$repeatOne = new Event();
+	$repeatTwo = new Event();
+
+	$em->dispatch($typedEvent);
+	$em->dispatch($repeatOne, 'listener.repeat.one');
+	$em->dispatch($repeatTwo, 'listener.repeat.two');
+
+	/** @var MethodAttributedListener $listener */
+	$listener = $container->getByType(MethodAttributedListener::class);
+	Assert::equal([$typedEvent], $listener->onTypedCall);
+	Assert::equal([$repeatOne, $repeatTwo], $listener->onRepeatedCall);
+});
+
+// Register class-level listeners with explicit and inferred methods.
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('events', new EventDispatcherExtension());
+			$compiler->addConfig(Neonkit::load(<<<'NEON'
+				services:
+					classListener: Tests\Fixtures\ClassAttributedListener
+					inferredListener: Tests\Fixtures\InferredMethodAttributedListener
+					invokableListener: Tests\Fixtures\InvokableAttributedListener
+			NEON
+			));
+		})->build();
+
+	/** @var EventDispatcherInterface $em */
+	$em = $container->getByType(EventDispatcherInterface::class);
+
+	$classEvent = new Event();
+	$inferredEvent = new Event();
+	$typedEvent = new TypedEvent();
+
+	$listeners = $em->getListeners('listener.class');
+	Assert::count(1, $listeners);
+	Assert::same(3, $em->getListenerPriority('listener.class', $listeners[0]));
+	Assert::true($em->hasListeners(TypedEvent::class));
+
+	$em->dispatch($classEvent, 'listener.class');
+	$em->dispatch($inferredEvent, 'listener.inferred');
+	$em->dispatch($typedEvent);
+
+	/** @var ClassAttributedListener $classListener */
+	$classListener = $container->getByType(ClassAttributedListener::class);
+	Assert::equal([$classEvent], $classListener->onCall);
+
+	/** @var InferredMethodAttributedListener $inferredListener */
+	$inferredListener = $container->getByType(InferredMethodAttributedListener::class);
+	Assert::equal([$inferredEvent], $inferredListener->onCall);
+
+	/** @var InvokableAttributedListener $invokableListener */
+	$invokableListener = $container->getByType(InvokableAttributedListener::class);
+	Assert::equal([$typedEvent], $invokableListener->onCall);
+});
+
+// Register listeners eagerly when lazy loading is disabled.
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('events', new EventDispatcherExtension());
+			$compiler->addConfig(Neonkit::load(<<<'NEON'
+				events:
+					lazy: false
+				services:
+					listener: Tests\Fixtures\MethodAttributedListener
+			NEON
+			));
+		})->build();
+
+	Assert::false($container->isCreated('listener'));
+
+	/** @var EventDispatcherInterface $em */
+	$em = $container->getByType(EventDispatcherInterface::class);
+
+	Assert::true($container->isCreated('listener'));
+
+	$event = new Event();
+	$em->dispatch($event, 'listener.method');
+
+	/** @var MethodAttributedListener $listener */
+	$listener = $container->getByType(MethodAttributedListener::class);
+	Assert::equal([$event], $listener->onMethodCall);
+});
+
+// Do not autoload attribute listeners when disabled.
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('events', new EventDispatcherExtension());
+			$compiler->addConfig(Neonkit::load(<<<'NEON'
+				events:
+					autoload: false
+				services:
+					listener: Tests\Fixtures\MethodAttributedListener
+			NEON
+			));
+		})->build();
+
+	/** @var EventDispatcherInterface $em */
+	$em = $container->getByType(EventDispatcherInterface::class);
+
+	Assert::false($em->hasListeners());
+	Assert::false($container->isCreated('listener'));
+});
+
+// Reject method attributes that declare a method name.
+Toolkit::test(function (): void {
+	Assert::exception(
+		static function (): void {
+			ContainerBuilder::of()
+				->withCompiler(function (Compiler $compiler): void {
+					$compiler->addExtension('events', new EventDispatcherExtension());
+					$compiler->addConfig(Neonkit::load(<<<'NEON'
+						services:
+							listener: Tests\Fixtures\InvalidMethodAttributeListener
+					NEON
+					));
+				})->build();
+		},
+		ServiceCreationException::class,
+		'#cannot declare method#',
+	);
+});
+
+// Reject inferred events without a concrete first argument type.
+Toolkit::test(function (): void {
+	Assert::exception(
+		static function (): void {
+			ContainerBuilder::of()
+				->withCompiler(function (Compiler $compiler): void {
+					$compiler->addExtension('events', new EventDispatcherExtension());
+					$compiler->addConfig(Neonkit::load(<<<'NEON'
+						services:
+							listener: Tests\Fixtures\InvalidInferredEventListener
+					NEON
+					));
+				})->build();
+		},
+		ServiceCreationException::class,
+		'~must define event in #\[AsEventListener\]~',
+	);
+});
+
+// Reject class attributes without a resolvable handler.
+Toolkit::test(function (): void {
+	Assert::exception(
+		static function (): void {
+			ContainerBuilder::of()
+				->withCompiler(function (Compiler $compiler): void {
+					$compiler->addExtension('events', new EventDispatcherExtension());
+					$compiler->addConfig(Neonkit::load(<<<'NEON'
+						services:
+							listener: Tests\Fixtures\InvalidClassAttributedListener
+					NEON
+					));
+				})->build();
+		},
+		ServiceCreationException::class,
+		'#public __invoke\(\) handler#',
+	);
+});

--- a/tests/Fixtures/ClassAttributedListener.php
+++ b/tests/Fixtures/ClassAttributedListener.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Contracts\EventDispatcher\Event;
+
+#[AsEventListener(event: 'listener.class', method: 'onClass', priority: 3)]
+final class ClassAttributedListener
+{
+
+	/** @var Event[] */
+	public array $onCall = [];
+
+	public function onClass(Event $event): void
+	{
+		$this->onCall[] = $event;
+	}
+
+}

--- a/tests/Fixtures/InferredMethodAttributedListener.php
+++ b/tests/Fixtures/InferredMethodAttributedListener.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Contracts\EventDispatcher\Event;
+
+#[AsEventListener(event: 'listener.inferred')]
+final class InferredMethodAttributedListener
+{
+
+	/** @var Event[] */
+	public array $onCall = [];
+
+	public function onListenerInferred(Event $event): void
+	{
+		$this->onCall[] = $event;
+	}
+
+}

--- a/tests/Fixtures/InvalidClassAttributedListener.php
+++ b/tests/Fixtures/InvalidClassAttributedListener.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener(event: 'listener.invalid.class')]
+final class InvalidClassAttributedListener
+{
+
+}

--- a/tests/Fixtures/InvalidInferredEventListener.php
+++ b/tests/Fixtures/InvalidInferredEventListener.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+final class InvalidInferredEventListener
+{
+
+	#[AsEventListener]
+	public function onInvalid(string $event): void
+	{
+		// Used by compile-time validation tests.
+	}
+
+}

--- a/tests/Fixtures/InvalidMethodAttributeListener.php
+++ b/tests/Fixtures/InvalidMethodAttributeListener.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class InvalidMethodAttributeListener
+{
+
+	#[AsEventListener(event: 'listener.invalid', method: 'onOther')]
+	public function onInvalid(Event $event): void
+	{
+		// Used by compile-time validation tests.
+	}
+
+}

--- a/tests/Fixtures/InvokableAttributedListener.php
+++ b/tests/Fixtures/InvokableAttributedListener.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener]
+final class InvokableAttributedListener
+{
+
+	/** @var TypedEvent[] */
+	public array $onCall = [];
+
+	public function __invoke(TypedEvent $event): void
+	{
+		$this->onCall[] = $event;
+	}
+
+}

--- a/tests/Fixtures/MethodAttributedListener.php
+++ b/tests/Fixtures/MethodAttributedListener.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class MethodAttributedListener
+{
+
+	/** @var Event[] */
+	public array $onMethodCall = [];
+
+	/** @var TypedEvent[] */
+	public array $onTypedCall = [];
+
+	/** @var Event[] */
+	public array $onRepeatedCall = [];
+
+	#[AsEventListener(event: 'listener.method', priority: 5)]
+	public function onMethod(Event $event): void
+	{
+		$this->onMethodCall[] = $event;
+	}
+
+	#[AsEventListener]
+	public function onTyped(TypedEvent $event): void
+	{
+		$this->onTypedCall[] = $event;
+	}
+
+	#[AsEventListener(event: 'listener.repeat.one', priority: 10)]
+	#[AsEventListener(event: 'listener.repeat.two')]
+	public function onRepeated(Event $event): void
+	{
+		$this->onRepeatedCall[] = $event;
+	}
+
+}

--- a/tests/Fixtures/TypedEvent.php
+++ b/tests/Fixtures/TypedEvent.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class TypedEvent extends Event
+{
+
+}


### PR DESCRIPTION
## Summary
- add autoloaded `#[AsEventListener]` discovery for method-level and class-level listeners, including lazy and eager registration paths
- support Symfony-style listener inference for typed class events, validate invalid attribute combinations at compile time, and cover the new behavior with dedicated fixtures/tests
- document listener usage in the package docs and update the root README PHP version note to match `composer.json`

Closes #45.